### PR TITLE
correct length at nesting level 0

### DIFF
--- a/mjpeg.go
+++ b/mjpeg.go
@@ -382,10 +382,12 @@ func (aw *aviWriter) Close() (err error) {
 		_, aw.err = io.Copy(aw.avif, aw.idxf)
 	}
 
+	pos := aw.currentPos()
 	aw.seek(aw.framesCountFieldPos, 0)
 	aw.writeInt32(int32(aw.frames))
 	aw.seek(aw.framesCountFieldPos2, 0)
 	aw.writeInt32(int32(aw.frames))
+	aw.seek(pos, 0)
 
 	aw.finalizeLengthField() // 'RIFF' File finished (nesting level 0)
 


### PR DESCRIPTION
The length of the video was wrong because the position was not at the end when we tried to compute the file length (nesting level 0). The field was always filled with the value 136